### PR TITLE
fix: update test cases to handle new json schema resolution

### DIFF
--- a/test/cli/jsonschema.spec.js
+++ b/test/cli/jsonschema.spec.js
@@ -54,7 +54,7 @@ describe('Response JSON schema', function () {
         let test = result.tests.find(t =>  t.name === this.test.title);
         expect(test.status).to.equal('fail');
         expect(test.error.name).to.equal('ResponseJSONSchemaValidationError');
-        expect(test.error.message).to.contain('Error occurred during response json schema validation');
+        expect(test.error.message).to.contain('Error opening file');
     });
 
     it('read inline invalid json schema and validate response - should fail', function () {
@@ -70,7 +70,7 @@ describe('Response JSON schema', function () {
         let test = result.tests.find(t =>  t.name === this.test.title);
         expect(test.status).to.equal('fail');
         expect(test.error.name).to.equal('ResponseJSONSchemaValidationError');
-        expect(test.error.message).to.contain('SyntaxError occurred while parsing the input schema');
+        expect(test.error.message).to.contain('Error parsing');
     });
 
     it('invalid input schema  - should fail', function () {

--- a/test/cli/src/static/schema/junk_simple_valid.json
+++ b/test/cli/src/static/schema/junk_simple_valid.json
@@ -1,5 +1,5 @@
-{
-  junk"$id": "http://example.com/example.json",
+{junk
+  "$id": "http://example.com/example.json",
   "type": "object",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "properties": {


### PR DESCRIPTION
Adding support for complex schemas broke the simplistic file read, and these tests expected specific failures. This change updates the expected behavior.

Fixes #4